### PR TITLE
tool.rb: Add original_link

### DIFF
--- a/lib/jekyll/planet/tool.rb
+++ b/lib/jekyll/planet/tool.rb
@@ -45,10 +45,11 @@ class Tool
 
     frontmatter =<<EOS
 ---
-title:      "#{item.title}"
+title:      "#{item.title.gsub("\"","\\\"")}"
 created_at: #{item.published}
 author:     #{item.feed.title}
 layout:     post
+original_link: "#{item.url unless item.url.empty?}"
 ---
 EOS
 


### PR DESCRIPTION
Also allow title to contain quotes instead of failing

Some enhancements for the gem
Especially providing a reference to the original post for providing due attribution in the generated planet site.